### PR TITLE
add error stripe marks

### DIFF
--- a/Photon - Light.icls
+++ b/Photon - Light.icls
@@ -1,10 +1,10 @@
 <scheme name="Photon - Light" version="142" parent_scheme="Default">
   <option name="FONT_SCALE" value="1.0" />
   <metaInfo>
-    <property name="created">2018-05-31T10:06:38</property>
+    <property name="created">2018-11-02T16:54:39</property>
     <property name="ide">PhpStorm</property>
-    <property name="ideVersion">2018.1.4.0.0</property>
-    <property name="modified">2018-05-31T10:06:41</property>
+    <property name="ideVersion">2018.2.5.0.0</property>
+    <property name="modified">2018-11-02T16:54:47</property>
     <property name="originalScheme">Photon - Light</property>
   </metaInfo>
   <option name="LINE_SPACING" value="1.6" />
@@ -362,6 +362,7 @@
     <option name="DEPRECATED_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="eb0000" />
+        <option name="ERROR_STRIPE_COLOR" value="dd0020" />
         <option name="EFFECT_TYPE" value="3" />
       </value>
     </option>
@@ -373,6 +374,7 @@
     <option name="ERRORS_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="eb0000" />
+        <option name="ERROR_STRIPE_COLOR" value="be2c13" />
         <option name="EFFECT_TYPE" value="4" />
       </value>
     </option>
@@ -391,6 +393,7 @@
     <option name="GENERIC_SERVER_ERROR_OR_WARNING">
       <value>
         <option name="FOREGROUND" value="cc6666" />
+        <option name="ERROR_STRIPE_COLOR" value="e69317" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
@@ -408,6 +411,7 @@
     <option name="IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="ccffcc" />
+        <option name="ERROR_STRIPE_COLOR" value="e2e2e2" />
       </value>
     </option>
     <option name="IGNORE.HEADER">
@@ -434,7 +438,8 @@
     </option>
     <option name="INFO_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="cc6666" />
+        <option name="EFFECT_COLOR" value="cccccc" />
+        <option name="ERROR_STRIPE_COLOR" value="d9cfad" />
         <option name="EFFECT_TYPE" value="5" />
       </value>
     </option>
@@ -604,11 +609,13 @@
     <option name="TEXT_SEARCH_RESULT_ATTRIBUTES">
       <value>
         <option name="EFFECT_COLOR" value="3eb0" />
+        <option name="ERROR_STRIPE_COLOR" value="c000" />
       </value>
     </option>
     <option name="TODO_DEFAULT_ATTRIBUTES">
       <value>
         <option name="FOREGROUND" value="6700" />
+        <option name="ERROR_STRIPE_COLOR" value="54aae3" />
       </value>
     </option>
     <option name="TWIG_BRACKETS">
@@ -653,13 +660,15 @@
     </option>
     <option name="WARNING_ATTRIBUTES">
       <value>
-        <option name="EFFECT_COLOR" value="cc6666" />
+        <option name="BACKGROUND" value="f6ebbc" />
+        <option name="ERROR_STRIPE_COLOR" value="ebc700" />
         <option name="EFFECT_TYPE" value="2" />
       </value>
     </option>
     <option name="WRITE_IDENTIFIER_UNDER_CARET_ATTRIBUTES">
       <value>
         <option name="BACKGROUND" value="b3ffb3" />
+        <option name="ERROR_STRIPE_COLOR" value="e6e6e6" />
       </value>
     </option>
     <option name="WRITE_SEARCH_RESULT_ATTRIBUTES">


### PR DESCRIPTION
Colors are taken from PhpStorm's default color scheme. These help me a lot in tasks such as refactoring legacy code.
![image](https://user-images.githubusercontent.com/305859/47926765-b0bc8780-dec1-11e8-92b9-b7287691b5f6.png)
